### PR TITLE
Can now reload profile / module safely

### DIFF
--- a/src/Module/Terminoid.psm1
+++ b/src/Module/Terminoid.psm1
@@ -23,6 +23,12 @@ function InitializeInternalVariables {
 
     $script:SpecialCharTable = $script:DefaultSpecialCharTable.Clone()
 
+    $promptFunction = Get-Item Function:\prompt -ErrorAction SilentlyContinue
+
+    if ( -not $promptFunction ) {
+        function global:prompt { }
+    }
+
     $script:DefaultPrompt = (Get-Item Function:\prompt).ScriptBlock
 
     Reset-DetailReader
@@ -67,3 +73,7 @@ Register-ArgumentCompleter -Native -CommandName git -ScriptBlock ${function:GitA
 InitializeInternalVariables
 ExportPublicFunctions
 RegisterKeyHandlers
+
+$ExecutionContext.SessionState.Module.OnRemove = {
+    Disable-TerminoidPrompt
+}


### PR DESCRIPTION
This used to mess up the custom prompt. It now uses a global function if it isn't there, and restores it to normal on module remove (which also occurs on dot-sourcing $profile). I stole this fix from posh-git, so credit where credit is due.