### PR TITLE
Fixing issue with returning first character of only choice

### DIFF
--- a/src/Module/public/Show-AutoCompletion.ps1
+++ b/src/Module/public/Show-AutoCompletion.ps1
@@ -35,6 +35,10 @@ function Show-AutoCompletion {
         return
     }
 
+    if ( -not ($items -is [Array]) ) {
+        $items = @($items)
+    }
+
     $cursor = GetCursorLocation
 
     $x = $cursor.Left

--- a/src/Module/tests/Show-AutoCompletion.Tests.ps1
+++ b/src/Module/tests/Show-AutoCompletion.Tests.ps1
@@ -61,5 +61,16 @@ InModuleScope Terminoid {
                 $selectedItem | Should -Be 'two'
             }
         }
+
+        Context 'Only one item to choose from' {
+            Mock ShowMenu { 0 }
+            Register-AutoCompletionHandler -Predicate { $true } -Function { 'item' }
+
+            $selectedItem = Show-AutoCompletion
+
+            It 'returns the selected item' {
+                $selectedItem | Should -Be 'item'
+            }
+        }
     }
 }


### PR DESCRIPTION
The subscript was referring to a single string, since it wasn't in an array. The answer here was to ensure every set of choices is in an array--even if it's only one.